### PR TITLE
feat: Add automatic missing value imputation

### DIFF
--- a/autoai/core/cleaner.py
+++ b/autoai/core/cleaner.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import numpy as np
+from sklearn.impute import SimpleImputer
+
+def impute_missing_values(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Imputes missing values in a DataFrame.
+
+    It uses the mean for numerical columns and the most frequent value
+    for categorical columns.
+
+    Args:
+        df (pd.DataFrame): The input DataFrame with potential missing values.
+
+    Returns:
+        pd.DataFrame: The DataFrame with missing values imputed.
+    """
+    print("Starting missing value imputation...")
+
+    # Make a copy to avoid modifying the original DataFrame
+    df_cleaned = df.copy()
+
+    # Identify numerical and categorical columns
+    numerical_cols = df_cleaned.select_dtypes(include=np.number).columns
+    categorical_cols = df_cleaned.select_dtypes(include=['object', 'category']).columns
+
+    # Impute numerical columns
+    if not df_cleaned[numerical_cols].isnull().sum().sum() == 0:
+        print(f"Imputing {len(numerical_cols)} numerical columns with mean strategy.")
+        num_imputer = SimpleImputer(strategy='mean')
+        df_cleaned[numerical_cols] = num_imputer.fit_transform(df_cleaned[numerical_cols])
+    else:
+        print("No missing values found in numerical columns.")
+
+    # Impute categorical columns
+    if not df_cleaned[categorical_cols].isnull().sum().sum() == 0:
+        print(f"Imputing {len(categorical_cols)} categorical columns with most_frequent strategy.")
+        cat_imputer = SimpleImputer(strategy='most_frequent')
+        df_cleaned[categorical_cols] = cat_imputer.fit_transform(df_cleaned[categorical_cols])
+    else:
+        print("No missing values found in categorical columns.")
+
+    print("Missing value imputation complete.")
+    return df_cleaned

--- a/data/sample_missing.csv
+++ b/data/sample_missing.csv
@@ -1,0 +1,6 @@
+id,name,age,city
+1,Alice,25,New York
+2,Bob,,London
+3,Charlie,35,
+4,David,40,Tokyo
+5,Eve,,

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 from autoai.core.data_loader import load_data
 from autoai.eda.report import generate_eda_report
+from autoai.core.cleaner import impute_missing_values
 
 def main():
     """Main function to run the AutoAI pipeline."""
@@ -28,6 +29,12 @@ def main():
         help="Path to save the generated EDA HTML report. e.g., --report eda_report.html"
     )
 
+    parser.add_argument(
+        '--clean',
+        action='store_true',
+        help='If set, the data will be automatically cleaned (e.g., missing value imputation).'
+    )
+
     args = parser.parse_args()
 
     print(f"Data path: {args.data}")
@@ -39,6 +46,12 @@ def main():
     if df is not None:
         print("\nData loaded successfully. First 5 rows:")
         print(df.head())
+
+        # Clean the data if requested
+        if args.clean:
+            df = impute_missing_values(df)
+            print("\nData after cleaning. First 5 rows:")
+            print(df.head())
 
         # Generate EDA report if requested
         if args.report:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ numpy
 # EDA & Visualization
 ydata-profiling
 sweetviz
+
+# Data Cleaning
+scikit-learn
+pyjanitor


### PR DESCRIPTION
- Adds scikit-learn and pyjanitor to the dependencies for data cleaning.
- Creates a new module `autoai/core/cleaner.py` to house data cleaning logic.
- Implements the `impute_missing_values` function, which uses scikit-learn's SimpleImputer to fill missing values automatically.
- The function applies the 'mean' strategy for numerical columns and the 'most_frequent' strategy for categorical columns.
- Integrates this cleaning feature into the main CLI, activated by a new `--clean` flag.
- Includes a new `data/sample_missing.csv` file to test and demonstrate this feature.