### PR TITLE
feat: Add hyperparameter tuning with Optuna

### DIFF
--- a/autoai/models/trainer.py
+++ b/autoai/models/trainer.py
@@ -1,81 +1,108 @@
 import pandas as pd
+import optuna
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, r2_score
 from xgboost import XGBClassifier, XGBRegressor
 from lightgbm import LGBMClassifier, LGBMRegressor
 from catboost import CatBoostClassifier, CatBoostRegressor
 
-def train_model(df: pd.DataFrame, target_column: str, task: str, model_name: str = 'xgboost'):
+def train_model(df: pd.DataFrame, target_column: str, task: str, model_name: str = 'xgboost', tune_hyperparameters: bool = False):
     """
-    Trains and evaluates a machine learning model.
+    Trains and evaluates a machine learning model, with an option for hyperparameter tuning.
 
     Args:
         df (pd.DataFrame): The input DataFrame.
         target_column (str): The name of the target variable column.
         task (str): The type of task ('classification' or 'regression').
         model_name (str): The name of the model to train.
+        tune_hyperparameters (bool): Whether to perform hyperparameter tuning.
 
     Returns:
-        A tuple containing the trained model and its evaluation score.
+        A tuple containing the trained model and its evaluation score on the test set.
     """
     print(f"\n--- Starting Model Training ---")
-    print(f"Model: {model_name}, Task: {task}, Target: {target_column}")
+    print(f"Model: {model_name}, Task: {task}, Target: {target_column}, Tuning: {tune_hyperparameters}")
 
     try:
-        # 1. Separate features (X) and target (y)
         X = df.drop(columns=[target_column])
         y = df[target_column]
-
-        # 2. One-hot encode categorical features
         X = pd.get_dummies(X, drop_first=True)
 
-        # Align columns after getting dummies - crucial for prediction later
-        # For now, this is handled implicitly by splitting after encoding.
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-        # 3. Split data into training and testing sets
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, test_size=0.2, random_state=42
-        )
-
-        print(f"Data split into training ({X_train.shape[0]} rows) and testing ({X_test.shape[0]} rows).")
-
-        # 4. Define model mappings
         models = {
-            'classification': {
-                'xgboost': XGBClassifier(random_state=42, eval_metric='logloss'),
-                'lightgbm': LGBMClassifier(random_state=42),
-                'catboost': CatBoostClassifier(random_state=42, verbose=0)
-            },
-            'regression': {
-                'xgboost': XGBRegressor(random_state=42),
-                'lightgbm': LGBMRegressor(random_state=42),
-                'catboost': CatBoostRegressor(random_state=42, verbose=0)
-            }
+            'classification': {'xgboost': XGBClassifier, 'lightgbm': LGBMClassifier, 'catboost': CatBoostClassifier},
+            'regression': {'xgboost': XGBRegressor, 'lightgbm': LGBMRegressor, 'catboost': CatBoostRegressor}
         }
 
-        if task not in models or model_name not in models[task]:
-            raise ValueError(f"Unsupported task '{task}' or model '{model_name}'.")
+        model_class = models[task][model_name]
+        best_params = {}
 
-        model = models[task][model_name]
+        if tune_hyperparameters:
+            print("\n--- Starting Hyperparameter Tuning with Optuna ---")
 
-        # 5. Train the model
-        print(f"Training {model_name} model...")
-        model.fit(X_train, y_train)
+            def _objective(trial):
+                if model_name == 'xgboost':
+                    params = {
+                        'n_estimators': trial.suggest_int('n_estimators', 100, 1000),
+                        'max_depth': trial.suggest_int('max_depth', 3, 10),
+                        'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3),
+                    }
+                elif model_name == 'lightgbm':
+                    params = {
+                        'n_estimators': trial.suggest_int('n_estimators', 100, 1000),
+                        'max_depth': trial.suggest_int('max_depth', 3, 10),
+                        'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3),
+                    }
+                elif model_name == 'catboost':
+                    params = {
+                        'iterations': trial.suggest_int('iterations', 100, 1000),
+                        'depth': trial.suggest_int('depth', 3, 10),
+                        'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3),
+                    }
+
+                model = model_class(**params, random_state=42)
+                if model_name == 'catboost':
+                    model.set_params(verbose=0)
+
+                # Use a validation set for tuning
+                X_train_part, X_val, y_train_part, y_val = train_test_split(X_train, y_train, test_size=0.25, random_state=42)
+                model.fit(X_train_part, y_train_part)
+                preds = model.predict(X_val)
+
+                if task == 'classification':
+                    return accuracy_score(y_val, preds)
+                else:
+                    return r2_score(y_val, preds)
+
+            study = optuna.create_study(direction='maximize')
+            study.optimize(_objective, n_trials=20) # Limit trials for speed
+
+            best_params = study.best_params
+            print(f"--- Tuning Finished ---")
+            print(f"Best trial score: {study.best_value:.4f}")
+            print(f"Best parameters found: {best_params}")
+
+        # Train final model
+        final_model = model_class(**best_params, random_state=42)
+        if model_name == 'catboost':
+             final_model.set_params(verbose=0)
+
+        print("\nTraining final model...")
+        final_model.fit(X_train, y_train) # Train on the full training set
         print("Training complete.")
 
-        # 6. Make predictions
-        y_pred = model.predict(X_test)
+        y_pred = final_model.predict(X_test)
 
-        # 7. Evaluate the model
         if task == 'classification':
             score = accuracy_score(y_test, y_pred)
-            print(f"Model Accuracy: {score:.4f}")
-        else: # regression
+            print(f"\nFinal Model Accuracy on Test Set: {score:.4f}")
+        else:
             score = r2_score(y_test, y_pred)
-            print(f"Model R-squared: {score:.4f}")
+            print(f"\nFinal Model R-squared on Test Set: {score:.4f}")
 
         print("--- Model Training Finished ---")
-        return model, score
+        return final_model, score
 
     except Exception as e:
         print(f"An error occurred during model training: {e}")

--- a/main.py
+++ b/main.py
@@ -44,6 +44,11 @@ def main():
         choices=["xgboost", "lightgbm", "catboost"],
         help="The machine learning model to train."
     )
+    parser.add_argument(
+        '--tune',
+        action='store_true',
+        help='If set, perform hyperparameter tuning for the selected model.'
+    )
 
     # --- Reporting ---
     parser.add_argument(
@@ -94,7 +99,8 @@ def main():
                 df=df,
                 target_column=args.target,
                 task=task,
-                model_name=args.model
+                model_name=args.model,
+                tune_hyperparameters=args.tune
             )
         else:
             print("\nNo target column specified. Skipping model training.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ pyjanitor
 xgboost
 lightgbm
 catboost
+
+# AutoML & Tuning
+optuna


### PR DESCRIPTION
- Adds `optuna` to the dependencies for hyperparameter optimization.
- Refactors the `autoai/models/trainer.py` module to support tuning.
- Implements an `_objective` function within the trainer to define search spaces and evaluate trials for different model types (XGBoost, LightGBM, CatBoost).
- The `train_model` function now runs an Optuna study to find the best parameters when the tuning flag is enabled.
- The final model is trained using the best-found hyperparameters on the full training set and evaluated on a held-out test set.
- Integrates the feature into the CLI with a new `--tune` flag.