### PR TITLE
Fix: Correct Mermaid syntax in architecture diagram

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -21,13 +21,13 @@ graph LR
     end
 
     subgraph Model Serving
-        C -- Loads --> J[Trained Model (.joblib)];
-        C -- Serves --> K[/predict Endpoint];
+        C -- Loads --> J["Trained Model (.joblib)"];
+        C -- Serves --> K["/predict Endpoint"];
     end
 
     subgraph Outputs
-        F --> L[EDA Report (.html)];
-        I --> M[SHAP Plot (.png)];
+        F --> L["EDA Report (.html)"];
+        I --> M["SHAP Plot (.png)"];
         G --> J;
     end
 


### PR DESCRIPTION
This commit fixes a rendering issue in the `architecture.md` file. The Mermaid diagram was failing to parse due to special characters in node labels (e.g., `.`, `()`).

The node labels containing these special characters have been enclosed in quotes to ensure they are parsed correctly as strings.