### PR TITLE
Update .gitignore to exclude generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Generated artifacts
+*.html
+*.png
+*.joblib


### PR DESCRIPTION
This commit updates the .gitignore file to exclude common files generated by running the AutoAI pipeline.

The following patterns have been added:
- `*.html`: For EDA reports.
- `*.png`: For SHAP plots and other images.
- `*.joblib`: For saved models.

This prevents generated artifacts from being accidentally committed to the repository.